### PR TITLE
Add Restore Original feature

### DIFF
--- a/PoeRedux/MainWindow.xaml
+++ b/PoeRedux/MainWindow.xaml
@@ -208,8 +208,18 @@
                        Foreground="{StaticResource DarkTextSecondary}"
                        Margin="8,0"/>
 
-            <Button Grid.Column="1" 
-                    Content="Apply Patches" 
+            <Button Grid.Column="1"
+                    Content="Restore Original"
+                    Click="RestoreButton_Click"
+                    MinWidth="120"
+                    FontSize="11"
+                    Margin="0,0,8,0"
+                    IsEnabled="False"
+                    Style="{StaticResource SecondaryButton}"
+                    x:Name="RestoreButton"/>
+
+            <Button Grid.Column="2"
+                    Content="Apply Patches"
                     Click="ApplyButton_Click"
                     MinWidth="100"
                     FontSize="11"

--- a/PoeRedux/MainWindow.xaml
+++ b/PoeRedux/MainWindow.xaml
@@ -211,9 +211,8 @@
             <Button Grid.Column="1"
                     Content="Restore Original"
                     Click="RestoreButton_Click"
-                    MinWidth="120"
+                    MinWidth="100"
                     FontSize="11"
-                    Margin="0,0,8,0"
                     IsEnabled="False"
                     Style="{StaticResource SecondaryButton}"
                     x:Name="RestoreButton"/>

--- a/PoeRedux/MainWindow.xaml.cs
+++ b/PoeRedux/MainWindow.xaml.cs
@@ -30,7 +30,11 @@ public partial class MainWindow : Window
         UpdateStatus();
 
         SourceInitialized += (s, e) => ApplyDarkTitleBar();
-        Loaded += async (s, e) => await CheckForUpdatesAsync();
+        Loaded += async (s, e) =>
+        {
+            UpdateRestoreButtonState();
+            await CheckForUpdatesAsync();
+        };
     }
 
     private void ApplyDarkTitleBar()
@@ -127,6 +131,8 @@ public partial class MainWindow : Window
         {
             ModsColorsButton.Visibility = _colorMods.Count > 0 ? Visibility.Visible : Visibility.Collapsed;
         }
+
+        UpdateRestoreButtonState();
     }
 
     private void ModsColorsButton_Click(object sender, RoutedEventArgs e)
@@ -226,8 +232,11 @@ public partial class MainWindow : Window
 
         StatusTextBlock.Text = "Starting patching process...";
 
+        var game = GameSelector?.SelectedIndex == 1 ? PoeGame.PoE2 : PoeGame.PoE1;
+
         // Disable buttons during operation
         ApplyButton.IsEnabled = false;
+        if (RestoreButton != null) RestoreButton.IsEnabled = false;
         //ZoomSlider.IsEnabled = false;
         ProgressBar.Visibility = Visibility.Visible;
         ProgressBar.IsIndeterminate = false;
@@ -239,24 +248,32 @@ public partial class MainWindow : Window
         {
             await Task.Run(() =>
             {
-                if (_ggpkPath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
+                BackupManager.Begin(game);
+                try
                 {
-                    var index = new LibBundle3.Index(_ggpkPath, false);
-                    index.ParsePaths();
-                    PatchIndex(index, patchesToApply);
-                    index.Dispose();
+                    if (_ggpkPath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var index = new LibBundle3.Index(_ggpkPath, false);
+                        index.ParsePaths();
+                        PatchIndex(index, patchesToApply);
+                        index.Dispose();
+                    }
+                    else if (_ggpkPath.EndsWith(".ggpk", StringComparison.OrdinalIgnoreCase))
+                    {
+                        BundledGGPK ggpk = new(_ggpkPath, false);
+                        var index = ggpk.Index;
+                        index.ParsePaths();
+                        PatchIndex(index, patchesToApply);
+                        ggpk.Dispose();
+                    }
+                    else
+                    {
+                        throw new InvalidDataException("The selected file is neither a GGPK nor an index BIN file.");
+                    }
                 }
-                else if (_ggpkPath.EndsWith(".ggpk", StringComparison.OrdinalIgnoreCase))
+                finally
                 {
-                    BundledGGPK ggpk = new(_ggpkPath, false);
-                    var index = ggpk.Index;
-                    index.ParsePaths();
-                    PatchIndex(index, patchesToApply);
-                    ggpk.Dispose();
-                }
-                else
-                {
-                    throw new InvalidDataException("The selected file is neither a GGPK nor an index BIN file.");
+                    BackupManager.End();
                 }
             });
 
@@ -275,7 +292,99 @@ public partial class MainWindow : Window
             ProgressBar.Visibility = Visibility.Collapsed;
             ProgressBar.Value = 0;
             //ZoomSlider.IsEnabled = true;
+            UpdateRestoreButtonState();
         }
+    }
+
+    private async void RestoreButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrEmpty(_ggpkPath) || !File.Exists(_ggpkPath))
+        {
+            MessageBox.Show("Please select a valid game file first.", "Invalid File");
+            return;
+        }
+
+        var game = GameSelector?.SelectedIndex == 1 ? PoeGame.PoE2 : PoeGame.PoE1;
+
+        if (!BackupManager.HasBackup(game))
+        {
+            MessageBox.Show("No backup found for this game.", "Nothing to Restore");
+            return;
+        }
+
+        var fileCount = BackupManager.CountBackedUpFiles(game);
+        StatusTextBlock.Text = $"Restoring {fileCount} file(s)...";
+
+        ApplyButton.IsEnabled = false;
+        if (RestoreButton != null) RestoreButton.IsEnabled = false;
+        ProgressBar.Visibility = Visibility.Visible;
+        ProgressBar.IsIndeterminate = false;
+        ProgressBar.Minimum = 0;
+        ProgressBar.Maximum = fileCount;
+        ProgressBar.Value = 0;
+
+        int restored = 0;
+        try
+        {
+            await Task.Run(() =>
+            {
+                void Progress(int done, int total, string path)
+                {
+                    Dispatcher.Invoke(() =>
+                    {
+                        StatusTextBlock.Text = $"Restoring ({done}/{total}): {Path.GetFileName(path)}";
+                        ProgressBar.Value = done;
+                    });
+                }
+
+                if (_ggpkPath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
+                {
+                    var index = new LibBundle3.Index(_ggpkPath, false);
+                    index.ParsePaths();
+                    restored = BackupManager.Restore(index, game, Progress);
+                    index.Save();
+                    index.Dispose();
+                }
+                else if (_ggpkPath.EndsWith(".ggpk", StringComparison.OrdinalIgnoreCase))
+                {
+                    BundledGGPK ggpk = new(_ggpkPath, false);
+                    var index = ggpk.Index;
+                    index.ParsePaths();
+                    restored = BackupManager.Restore(index, game, Progress);
+                    index.Save();
+                    ggpk.Dispose();
+                }
+                else
+                {
+                    throw new InvalidDataException("The selected file is neither a GGPK nor an index BIN file.");
+                }
+            });
+
+            BackupManager.DeleteBackup(game);
+            StatusTextBlock.Text = $"Restored {restored} file(s) to original.";
+            MessageBox.Show($"Restored {restored} file(s) to original.\n\nBackup cleared.", "Restore Complete");
+        }
+        catch (Exception ex)
+        {
+            StatusTextBlock.Text = "Error occurred while restoring.";
+            MessageBox.Show($"Error restoring:\n\n{ex.Message}", "Error");
+        }
+        finally
+        {
+            ApplyButton.IsEnabled = true;
+            ProgressBar.Visibility = Visibility.Collapsed;
+            ProgressBar.Value = 0;
+            UpdateRestoreButtonState();
+        }
+    }
+
+    private void UpdateRestoreButtonState()
+    {
+        if (RestoreButton == null) return;
+        var game = GameSelector?.SelectedIndex == 1 ? PoeGame.PoE2 : PoeGame.PoE1;
+        var count = BackupManager.CountBackedUpFiles(game);
+        RestoreButton.IsEnabled = count > 0;
+        RestoreButton.Content = count > 0 ? $"Restore Original ({count})" : "Restore Original";
     }
 
     private void PatchIndex(LibBundle3.Index index, List<PatchViewModel> patches)

--- a/PoeRedux/MainWindow.xaml.cs
+++ b/PoeRedux/MainWindow.xaml.cs
@@ -253,18 +253,16 @@ public partial class MainWindow : Window
                 {
                     if (_ggpkPath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
                     {
-                        var index = new LibBundle3.Index(_ggpkPath, false);
+                        using var index = new LibBundle3.Index(_ggpkPath, false);
                         index.ParsePaths();
                         PatchIndex(index, patchesToApply);
-                        index.Dispose();
                     }
                     else if (_ggpkPath.EndsWith(".ggpk", StringComparison.OrdinalIgnoreCase))
                     {
-                        BundledGGPK ggpk = new(_ggpkPath, false);
+                        using BundledGGPK ggpk = new(_ggpkPath, false);
                         var index = ggpk.Index;
                         index.ParsePaths();
                         PatchIndex(index, patchesToApply);
-                        ggpk.Dispose();
                     }
                     else
                     {
@@ -332,27 +330,25 @@ public partial class MainWindow : Window
                 {
                     Dispatcher.Invoke(() =>
                     {
-                        StatusTextBlock.Text = $"Restoring ({done}/{total}): {Path.GetFileName(path)}";
+                        StatusTextBlock.Text = $"Restoring ({done}/{total})";
                         ProgressBar.Value = done;
                     });
                 }
 
                 if (_ggpkPath.EndsWith(".bin", StringComparison.OrdinalIgnoreCase))
                 {
-                    var index = new LibBundle3.Index(_ggpkPath, false);
+                    using var index = new LibBundle3.Index(_ggpkPath, false);
                     index.ParsePaths();
                     restored = BackupManager.Restore(index, game, Progress);
                     index.Save();
-                    index.Dispose();
                 }
                 else if (_ggpkPath.EndsWith(".ggpk", StringComparison.OrdinalIgnoreCase))
                 {
-                    BundledGGPK ggpk = new(_ggpkPath, false);
+                    using BundledGGPK ggpk = new(_ggpkPath, false);
                     var index = ggpk.Index;
                     index.ParsePaths();
                     restored = BackupManager.Restore(index, game, Progress);
                     index.Save();
-                    ggpk.Dispose();
                 }
                 else
                 {

--- a/PoeRedux/Patches/Black/Aoc.cs
+++ b/PoeRedux/Patches/Black/Aoc.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -133,6 +134,7 @@ public partial class Aoc : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/Env.cs
+++ b/PoeRedux/Patches/Black/Env.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -106,6 +107,7 @@ public class Env : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/Epk.cs
+++ b/PoeRedux/Patches/Black/Epk.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -42,6 +43,7 @@ public class Epk : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/Ffx.cs
+++ b/PoeRedux/Patches/Black/Ffx.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -52,6 +53,7 @@ public class Ffx : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/Hlsl.cs
+++ b/PoeRedux/Patches/Black/Hlsl.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -85,6 +86,7 @@ public class Hlsl : IPatch
         }
 
         var newBytes = System.Text.Encoding.UTF8.GetBytes(data);
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/Mat.cs
+++ b/PoeRedux/Patches/Black/Mat.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -41,6 +42,7 @@ public class Mat : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Black/NoCorpse.cs
+++ b/PoeRedux/Patches/Black/NoCorpse.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -38,6 +39,7 @@ public class NoCorpse : IPatch
         data = data.Replace("slow_animations_go_to_idle = true\r\n}", "slow_animations_go_to_idle = true\r\n\ton_start_Revive = {RemoveEffects(); EnableRendering();}\r\n}");
 
         var newBytes = Encoding.Unicode.GetBytes(data);
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 }

--- a/PoeRedux/Patches/Black/Pet.cs
+++ b/PoeRedux/Patches/Black/Pet.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches.Black;
 
@@ -42,6 +43,7 @@ public class Pet : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Camera.cs
+++ b/PoeRedux/Patches/Camera.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -133,6 +134,7 @@ public class Camera : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 
@@ -186,6 +188,7 @@ public class Camera : IPatch
                 }
                 string newData = string.Join("\r\n", lines);
                 var newBytes = Encoding.Unicode.GetBytes(newData);
+                BackupManager.RecordOriginal(record);
                 record.Write(newBytes);
             }
         }

--- a/PoeRedux/Patches/ColorMods.cs
+++ b/PoeRedux/Patches/ColorMods.cs
@@ -1,7 +1,8 @@
-﻿using LibBundle3.Nodes;
+using LibBundle3.Nodes;
 using PoeRedux.Models;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -243,6 +244,7 @@ public class ColorMods : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Corpse.cs
+++ b/PoeRedux/Patches/Corpse.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -38,6 +39,7 @@ public class Corpse : IPatch
         data = data.Replace("slow_animations_go_to_idle = true\r\n}", "slow_animations_go_to_idle = true\r\n\ton_start_Revive = {RemoveEffects(); EnableRendering();}\r\n}");
 
         var newBytes = Encoding.Unicode.GetBytes(data);
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 }

--- a/PoeRedux/Patches/Delirium.cs
+++ b/PoeRedux/Patches/Delirium.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -83,6 +84,7 @@ client
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Effects.cs
+++ b/PoeRedux/Patches/Effects.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -178,6 +179,7 @@ public partial class Effects : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/EnvironmentParticles.cs
+++ b/PoeRedux/Patches/EnvironmentParticles.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -52,6 +53,7 @@ public class EnvironmentParticles : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Fog.cs
+++ b/PoeRedux/Patches/Fog.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -48,6 +49,7 @@ public class Fog : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Light.cs
+++ b/PoeRedux/Patches/Light.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -51,6 +52,7 @@ public class Light : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Minimap.cs
+++ b/PoeRedux/Patches/Minimap.cs
@@ -1,4 +1,5 @@
 using LibBundle3.Nodes;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -45,6 +46,7 @@ public class Minimap : IPatch
 
                 string newData = string.Join("\r\n", lines);
                 var newBytes = System.Text.Encoding.ASCII.GetBytes(newData);
+                BackupManager.RecordOriginal(record);
                 record.Write(newBytes);
             }
             
@@ -58,6 +60,7 @@ public class Minimap : IPatch
                 data = data.Replace("float4 walkability_map_color = lerp(walkable_color, float4(0.5f, 0.5f, 1.0f, 0.5f), walkable_to_edge_ratio);", "float4 walkability_map_color = lerp(walkable_color, float4(12.0f, 12.0f, 12.0f, 0.1f), walkable_to_edge_ratio);");
                 
                 var newBytes = System.Text.Encoding.ASCII.GetBytes(data);
+                BackupManager.RecordOriginal(record);
                 record.Write(newBytes);
             }
         }

--- a/PoeRedux/Patches/Particles.cs
+++ b/PoeRedux/Patches/Particles.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -62,6 +63,7 @@ public class Particles : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches/Shadow.cs
+++ b/PoeRedux/Patches/Shadow.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -48,6 +49,7 @@ public class Shadow : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches2/AtlasFog.cs
+++ b/PoeRedux/Patches2/AtlasFog.cs
@@ -1,5 +1,6 @@
 using LibBundle3.Nodes;
 using System.Text;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -73,6 +74,7 @@ public class AtlasFog : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 }

--- a/PoeRedux/Patches2/Clouds.cs
+++ b/PoeRedux/Patches2/Clouds.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -51,6 +52,7 @@ public class Clouds : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches2/EnvironmentParticles2.cs
+++ b/PoeRedux/Patches2/EnvironmentParticles2.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -61,6 +62,7 @@ public class EnvironmentParticles2 : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Patches2/Rain.cs
+++ b/PoeRedux/Patches2/Rain.cs
@@ -1,6 +1,7 @@
 using LibBundle3.Nodes;
 using System.Text;
 using System.Text.RegularExpressions;
+using PoeRedux.Services;
 
 namespace PoeRedux.Patches;
 
@@ -51,6 +52,7 @@ public class Rain : IPatch
         {
             newBytes = [.. Encoding.Unicode.GetPreamble(), .. newBytes];
         }
+        BackupManager.RecordOriginal(record);
         record.Write(newBytes);
     }
 

--- a/PoeRedux/Services/BackupManager.cs
+++ b/PoeRedux/Services/BackupManager.cs
@@ -1,0 +1,202 @@
+using LibBundle3;
+using LibBundle3.Records;
+using System.IO;
+using System.Text;
+
+namespace PoeRedux.Services;
+
+public enum PoeGame
+{
+    PoE1,
+    PoE2,
+}
+
+/// <summary>
+/// Captures original file bytes before patches overwrite them, and restores them on
+/// demand. Crash-safe streaming format: each entry is appended immediately, so a
+/// mid-patch crash still leaves a recoverable partial backup.
+///
+/// Usage:
+///   BackupManager.Begin(game);
+///   try {
+///       // patches call BackupManager.RecordOriginal(record) before record.Write(...)
+///   } finally {
+///       BackupManager.End();
+///   }
+///
+///   // later:
+///   BackupManager.Restore(index, game);
+///   index.Save();
+///   BackupManager.DeleteBackup(game);
+/// </summary>
+public static class BackupManager
+{
+    private const uint MAGIC = 0x4B425350; // "PSBK"
+    private const int VERSION = 1;
+
+    private static readonly object _lock = new();
+    private static FileStream? _stream;
+    private static HashSet<string>? _knownPaths;
+
+    public static string GetBackupFilePath(PoeGame game)
+    {
+        var dir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PoeRedux", "Backups");
+        Directory.CreateDirectory(dir);
+        var name = game == PoeGame.PoE2 ? "poe2.bak" : "poe1.bak";
+        return Path.Combine(dir, name);
+    }
+
+    public static bool HasBackup(PoeGame game) => File.Exists(GetBackupFilePath(game));
+
+    public static int CountBackedUpFiles(PoeGame game)
+    {
+        if (!HasBackup(game)) return 0;
+        try { return ReadAllEntries(GetBackupFilePath(game)).Count; }
+        catch { return 0; }
+    }
+
+    /// <summary>Open a session. Existing entries (from prior sessions) are preserved
+    /// and their paths are skipped — so the very first original we ever saw stays as
+    /// truth even if patches are re-applied without restoring first.</summary>
+    public static void Begin(PoeGame game)
+    {
+        lock (_lock)
+        {
+            End();
+
+            var path = GetBackupFilePath(game);
+            _knownPaths = new HashSet<string>(StringComparer.Ordinal);
+
+            if (File.Exists(path))
+            {
+                try
+                {
+                    foreach (var entry in ReadAllEntries(path))
+                        _knownPaths.Add(entry.Path);
+                }
+                catch
+                {
+                    File.Delete(path);
+                    _knownPaths.Clear();
+                }
+            }
+
+            var newFile = !File.Exists(path);
+            _stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            if (newFile)
+            {
+                using var bw = new BinaryWriter(_stream, Encoding.UTF8, leaveOpen: true);
+                bw.Write(MAGIC);
+                bw.Write(VERSION);
+                bw.Write((int)game);
+                bw.Flush();
+            }
+            _stream.Seek(0, SeekOrigin.End);
+        }
+    }
+
+    /// <summary>Capture this file's current bytes as "original" before a patch
+    /// overwrites it. Patches call this immediately before <c>record.Write(...)</c>.
+    /// If the path is already in the backup, this is a fast no-op.</summary>
+    public static void RecordOriginal(FileRecord record)
+    {
+        if (record == null) return;
+
+        lock (_lock)
+        {
+            if (_stream == null || _knownPaths == null) return;
+
+            var path = record.Path ?? string.Empty;
+            if (string.IsNullOrEmpty(path)) return;
+            if (!_knownPaths.Add(path)) return;
+
+            var originalBytes = record.Read();
+
+            var pathBytes = Encoding.UTF8.GetBytes(path);
+            using var bw = new BinaryWriter(_stream, Encoding.UTF8, leaveOpen: true);
+            bw.Write(pathBytes.Length);
+            bw.Write(pathBytes);
+            bw.Write(originalBytes.Length);
+            bw.Write(originalBytes.Span);
+            bw.Flush();
+        }
+    }
+
+    public static void End()
+    {
+        lock (_lock)
+        {
+            _stream?.Dispose();
+            _stream = null;
+            _knownPaths = null;
+        }
+    }
+
+    /// <summary>Apply backed-up originals back into the index. Caller is responsible
+    /// for opening the index, calling <c>index.Save()</c>, and disposing.</summary>
+    public static int Restore(LibBundle3.Index index, PoeGame game, Action<int, int, string>? progress = null)
+    {
+        var path = GetBackupFilePath(game);
+        if (!File.Exists(path)) return 0;
+
+        var entries = ReadAllEntries(path);
+        int done = 0;
+        for (int i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            progress?.Invoke(i + 1, entries.Count, entry.Path);
+            if (index.TryGetFile(entry.Path, out var record))
+            {
+                record.Write(entry.Bytes, false);
+                done++;
+            }
+        }
+        return done;
+    }
+
+    public static void DeleteBackup(PoeGame game)
+    {
+        var path = GetBackupFilePath(game);
+        if (File.Exists(path))
+        {
+            try { File.Delete(path); } catch { /* best effort */ }
+        }
+    }
+
+    public record BackupEntry(string Path, byte[] Bytes);
+
+    private static List<BackupEntry> ReadAllEntries(string filePath)
+    {
+        var list = new List<BackupEntry>();
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var br = new BinaryReader(fs, Encoding.UTF8, leaveOpen: true);
+
+        if (fs.Length < 12) return list;
+
+        var magic = br.ReadUInt32();
+        if (magic != MAGIC) throw new InvalidDataException("Not a PoeRedux backup file.");
+        var version = br.ReadInt32();
+        if (version != VERSION) throw new InvalidDataException($"Unsupported backup version: {version}");
+        _ = br.ReadInt32();
+
+        while (fs.Position < fs.Length)
+        {
+            try
+            {
+                int pathLen = br.ReadInt32();
+                if (pathLen <= 0 || pathLen > 4096) break;
+                var pathBytes = br.ReadBytes(pathLen);
+                if (pathBytes.Length != pathLen) break;
+                int dataLen = br.ReadInt32();
+                if (dataLen < 0 || fs.Position + dataLen > fs.Length) break;
+                var data = br.ReadBytes(dataLen);
+                if (data.Length != dataLen) break;
+                list.Add(new BackupEntry(Encoding.UTF8.GetString(pathBytes), data));
+            }
+            catch (EndOfStreamException) { break; }
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a one-click **Restore Original** feature so users can revert patched bundles without running Steam's "Verify Integrity" or PackCheck (which redownloads several gigabytes).

When patches are applied, the original bytes of every modified file are captured to a small per-game backup at `%LocalAppData%\PoeRedux\Backups\poe[1|2].bak`. The new button reads that backup and writes the original bytes back into the bundle index.

## How it works

- `BackupManager.Begin(game)` is called before the patch loop and `End()` after, in `MainWindow.ApplyPatches`.
- Each patch's `record.Write(...)` site now has `BackupManager.RecordOriginal(record)` immediately before it. `RecordOriginal` dedupes by `record.Path`, so the very first original we ever capture is preserved even if the user re-applies patches without restoring first (otherwise the second pass would capture already-patched bytes as the "original").
- The on-disk format is a length-prefixed binary stream that's appended and flushed entry-by-entry, so a mid-patch crash still yields a recoverable partial backup.
- Restore opens the index, calls `Index.TryGetFile(path)` for each backup entry, writes the original bytes back, then `index.Save()`. The backup file is deleted on success so the next Apply starts a fresh true-original capture.

## UI

- "Restore Original" button shown next to "Apply Patches".
- Disabled when no backup exists; otherwise shows the count, e.g. `Restore Original (12)`.
- Refreshes when the user switches between PoE 1 and PoE 2 (each game has its own backup).

## Files changed

- `PoeRedux/Services/BackupManager.cs` (new) — backup/restore implementation + `PoeGame` enum
- `PoeRedux/MainWindow.xaml` — adds Restore button
- `PoeRedux/MainWindow.xaml.cs` — wraps `ApplyPatches` with backup session, adds `RestoreButton_Click` and `UpdateRestoreButtonState`
- `PoeRedux/Patches/**/*.cs` and `PoeRedux/Patches2/*.cs` — one-line addition before each `record.Write(...)` to capture the original bytes

## Test plan

- [x] Builds cleanly (`dotnet build`)
- [x] Apply a patch, verify the Restore button enables and shows the file count
- [ ] Click Restore, confirm patched files revert without needing Steam Verify
- [ ] Switch between PoE 1 and PoE 2, verify backups are independent
- [ ] Apply patches twice without restoring; confirm the backup still holds the true originals (not the already-patched bytes)

## Notes

- No new package dependencies; uses only `System.IO` and the existing `LibBundle3`.
- Backward-compatible: if no backup exists, the button is just disabled — existing flows are unchanged.