### PR TITLE
Fix fatal startup crash (0x80131506) by disabling CETCompat

### DIFF
--- a/PoeRedux/PoeRedux.csproj
+++ b/PoeRedux/PoeRedux.csproj
@@ -9,6 +9,8 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>..\icon.ico</ApplicationIcon>
     <Version>1.1.9</Version>
+    <!-- Disables CET / shadow-stack on the exe to avoid a fatal startup crash (0x80131506) caused by the native non-CET-aware oo2core.dll. See issue #29. -->
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
## Summary
Fixes #29 — a fatal CLR error `0x80131506` (`COR_E_EXECUTIONENGINE`) that crashes the app on startup for some users.

## Root cause
On x64 the produced executable opts into CET / shadow-stack (`IMAGE_DLLCHARACTERISTICS_EX_CET_COMPAT`) by default. On CPUs that enforce CET this faults, because the bundled native `oo2core.dll` (Oodle) is not CET-aware, so the CLR aborts with the execution-engine error. A user in #29 confirmed that disabling CETCompat resolves it.

## Fix
Add `<CETCompat>false</CETCompat>` to `PoeRedux.csproj`, which clears the CET flag on the produced exe. One line, no behavior change for users who were not affected.

## Verification
Parsed the PE extended DLL characteristics of the published single-file exe before/after:

| Build | Ext. DLL Characteristics | CET compatible |
|-------|--------------------------|----------------|
| before (default) | `0x0001` | yes (crashing) |
| after (this PR)  | `0x0000` | no |

`dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true` builds cleanly (0 warnings, 0 errors).

---
Hey @Gineticus 👋 small fix for the startup crash — from PanCrucian.

Checked by human real flow